### PR TITLE
feat(profile): Add actions for profile comments

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,2 +1,3 @@
+export * from './profile';
 export * from './search';
 export * from './users';

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -8,3 +8,12 @@ export const getComments = ({ user, ...rest }) => laboratoriaAPIAction({
   expiration: 1000 * 60 * 5,
   ...rest,
 });
+
+export const addComment = ({ user, comment, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_COMMENT_ADD',
+  url: `/users/${user}/profile/comments`,
+  method: 'POST',
+  data: comment,
+  key: 'profile-comment-add',
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -17,3 +17,16 @@ export const addComment = ({ user, comment, ...rest }) => laboratoriaAPIAction({
   key: 'profile-comment-add',
   ...rest,
 });
+
+export const updateComment = ({
+  user,
+  comment: { id: commentId, ...data },
+  ...rest
+}) => laboratoriaAPIAction({
+  type: 'PROFILE_COMMENT_UPDATE',
+  url: `/users/${user}/profile/comments/${commentId}`,
+  method: 'PUT',
+  data,
+  key: 'profile-comment-update',
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -1,0 +1,10 @@
+import { laboratoriaAPIAction } from '../helpers';
+
+export const getComments = ({ user, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_COMMENTS',
+  url: `/users/${user}/profile/comments`,
+  method: 'GET',
+  key: `user/${user}/profile/comments`,
+  expiration: 1000 * 60 * 5,
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -30,3 +30,11 @@ export const updateComment = ({
   key: 'profile-comment-update',
   ...rest,
 });
+
+export const deleteComment = ({ user, commentId, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_COMMENT_DELETE',
+  url: `/users/${user}/profile/comments/${commentId}`,
+  method: 'DELETE',
+  key: 'profile-comment-delete',
+  ...rest,
+});

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addComment should create an appropiate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-comment-add",
+    "namespace": "default",
+    "suffix": "PROFILE_COMMENT_ADD",
+  },
+  "payload": Object {
+    "data": Object {
+      "cohortProject": "cohortProjectId",
+      "text": "text",
+      "type": "type",
+    },
+    "headers": undefined,
+    "method": "POST",
+    "params": undefined,
+    "url": "/users/someone/profile/comments",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_COMMENT_ADD",
+}
+`;
+
+exports[`deleteComment should create an appropiate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-comment-delete",
+    "namespace": "default",
+    "suffix": "PROFILE_COMMENT_DELETE",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "DELETE",
+    "params": undefined,
+    "url": "/users/someone/profile/comments/commentId",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_COMMENT_DELETE",
+}
+`;
+
+exports[`getComments should create an appropiate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 300000,
+    "key": "user/someone/profile/comments",
+    "namespace": "default",
+    "suffix": "PROFILE_COMMENTS",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/users/someone/profile/comments",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_COMMENTS",
+}
+`;
+
+exports[`updateComment should create an appropiate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-comment-update",
+    "namespace": "default",
+    "suffix": "PROFILE_COMMENT_UPDATE",
+  },
+  "payload": Object {
+    "data": Object {
+      "text": "text",
+    },
+    "headers": undefined,
+    "method": "PUT",
+    "params": undefined,
+    "url": "/users/someone/profile/comments/commentId",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_COMMENT_UPDATE",
+}
+`;

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -1,0 +1,62 @@
+import {
+  getComments,
+  addComment,
+  updateComment,
+  deleteComment,
+} from '../../lib/actions/profile';
+
+describe('getComments', () => {
+  it('should be a function', () => {
+    expect(typeof getComments).toBe('function');
+  });
+
+  it('should create an appropiate action', () => {
+    expect(getComments({ user: 'someone' })).toMatchSnapshot();
+  });
+});
+
+describe('addComment', () => {
+  it('should be a function', () => {
+    expect(typeof addComment).toBe('function');
+  });
+
+  it('should create an appropiate action', () => {
+    expect(addComment({
+      user: 'someone',
+      comment: {
+        cohortProject: 'cohortProjectId',
+        type: 'type',
+        text: 'text',
+      },
+    })).toMatchSnapshot();
+  });
+});
+
+describe('updateComment', () => {
+  it('should be a function', () => {
+    expect(typeof updateComment).toBe('function');
+  });
+
+  it('should create an appropiate action', () => {
+    expect(updateComment({
+      user: 'someone',
+      comment: {
+        id: 'commentId',
+        text: 'text',
+      },
+    })).toMatchSnapshot();
+  });
+});
+
+describe('deleteComment', () => {
+  it('should be a function', () => {
+    expect(typeof deleteComment).toBe('function');
+  });
+
+  it('should create an appropiate action', () => {
+    expect(deleteComment({
+      user: 'someone',
+      commentId: 'commentId',
+    })).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This pull request implements the necessary **actions** to consume the endpoints of the academic profile (comments only), as well as the corresponding _tests_.