### PR TITLE
feat(user): Add action for GET endpoint of user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,3 +280,10 @@ Get user events feed.
 ##### Params
 - `user`: User ID or email to get the feed from.
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+#### `userProfile({ user, ...rest })`
+Get user's academic profile.
+
+##### Params
+- `user`: User ID or email to get the academic profile from.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.

--- a/lib/actions/users/index.js
+++ b/lib/actions/users/index.js
@@ -17,3 +17,12 @@ export const userFeed = ({ user, ...rest }) => laboratoriaAPIAction({
   expiration: 1000 * 60 * 1,
   ...rest,
 });
+
+export const userProfile = ({ user, ...rest }) => laboratoriaAPIAction({
+  type: 'USER_PROFILE',
+  url: `/users/${user}/profile`,
+  method: 'GET',
+  key: `user/${user}/profile`,
+  expiration: 1000 * 60 * 5,
+  ...rest,
+});

--- a/test/actions/__snapshots__/users.spec.js.snap
+++ b/test/actions/__snapshots__/users.spec.js.snap
@@ -39,3 +39,23 @@ Object {
   "type": "@@api-client/API_REQUEST/USER_FEED",
 }
 `;
+
+exports[`userProfile should create an appropriate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 300000,
+    "key": "user/someone/profile",
+    "namespace": "default",
+    "suffix": "USER_PROFILE",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/users/someone/profile",
+  },
+  "type": "@@api-client/API_REQUEST/USER_PROFILE",
+}
+`;

--- a/test/actions/users.spec.js
+++ b/test/actions/users.spec.js
@@ -1,4 +1,4 @@
-import { userCohorts, userFeed } from '../../lib/actions/users';
+import { userCohorts, userFeed, userProfile } from '../../lib/actions/users';
 
 describe('userCohorts', () => {
   it('should be a function', () => {
@@ -17,5 +17,15 @@ describe('userFeed', () => {
 
   it('should create an appropriate action', () => {
     expect(userFeed({ user: 'someone' })).toMatchSnapshot();
+  });
+});
+
+describe('userProfile', () => {
+  it('should be a function', () => {
+    expect(typeof userProfile).toBe('function');
+  });
+
+  it('should create an appropriate action', () => {
+    expect(userProfile({ user: 'someone' })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This adds an action to use  user profile **GET endpoint**, including:

- User profile action
- Tests of user profile action
- Snapshot for user profile action