### PR TITLE
feat(cohort): Add action for GET endpoint of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ Get cohorts list, optionally filtered by campus, program and track.
 - `limit`: Number of elements to retrieve per page. Defaults to 100.
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
 
+#### `getCohortUsers({ cohort, ...rest })`
+Returns the list of users from a cohort.
+
+##### Params
+- `cohort`: Cohort slug used to obtain the users that belong to that cohort..
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
 ### Feedback
 #### `addProjectFeedback({ user, cohortId, projectId, data, ...rest })`
 Add feedback for a user's cohort project.

--- a/lib/actions/cohorts/index.js
+++ b/lib/actions/cohorts/index.js
@@ -22,3 +22,12 @@ export const getCohorts = ({
   expiration: 1000 * 60 * 60,
   ...rest,
 });
+
+export const getCohortUsers = ({ cohort, ...rest }) => laboratoriaAPIAction({
+  type: 'COHORT_USERS',
+  url: `/cohorts/${cohort}/users`,
+  method: 'GET',
+  key: `/cohorts/${cohort}/users`,
+  expiration: 1000 * 60 * 5,
+  ...rest,
+});

--- a/test/actions/__snapshots__/cohorts.spec.js.snap
+++ b/test/actions/__snapshots__/cohorts.spec.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCohortUsers should create an appropriate action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 300000,
+    "key": "/cohorts/something/users",
+    "namespace": "default",
+    "suffix": "COHORT_USERS",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/cohorts/something/users",
+  },
+  "type": "@@api-client/API_REQUEST/COHORT_USERS",
+}
+`;
+
 exports[`getCohorts should create an appropriate action 1`] = `
 Object {
   "meta": Object {

--- a/test/actions/cohorts.spec.js
+++ b/test/actions/cohorts.spec.js
@@ -1,4 +1,4 @@
-import { getCohorts } from '../../lib/actions/cohorts';
+import { getCohorts, getCohortUsers } from '../../lib/actions/cohorts';
 
 describe('getCohorts', () => {
   it('should be a function', () => {
@@ -7,5 +7,15 @@ describe('getCohorts', () => {
 
   it('should create an appropriate action', () => {
     expect(getCohorts()).toMatchSnapshot();
+  });
+});
+
+describe('getCohortUsers', () => {
+  it('should be a function', () => {
+    expect(typeof getCohortUsers).toBe('function');
+  });
+
+  it('should create an appropriate action', () => {
+    expect(getCohortUsers({ cohort: 'something' })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This adds an action to use cohort users GET endpoint, including:

- getCohortUsers action
- Tests of getCohortUsers action
- Snapshot for getCohortUsers action
- Documentation for getCohortUsers  action