### PR TITLE
feat(cohorts/projects): Add actions getProjects, getCohortProjects and addCohortProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ Returns the list of users from a cohort.
 - `cohort`: Cohort slug used to obtain the users that belong to that cohort..
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
 
+#### `getCohortProjects({ cohort, ...rest })`
+Returns the list of projects added to a cohort.
+
+##### Params
+- `cohort`: Cohort slug used to obtain the projects that belong to that cohort.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+#### `addCohortProject({ cohort, project, ...rest })`
+Add project for a cohort.
+
+##### Params
+- `cohort`: Cohort slug used to identify the cohort where the project will be added to.
+- `project`: Identifier of the project to be added.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
 ### Feedback
 #### `addProjectFeedback({ user, cohortId, projectId, data, ...rest })`
 Add feedback for a user's cohort project.
@@ -252,6 +267,13 @@ Update a user's profile comment.
 ##### Params
 - `user`: User ID or email whose profile the comment will be updated from.
 - `comment`: Object representing the comment to update. Must contain an `id` property.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+### Campuses
+#### `getCampuses({ ...rest })`
+Get projects list.
+
+##### Params
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
 
 ### Reviewer Survey

--- a/lib/actions/cohorts/index.js
+++ b/lib/actions/cohorts/index.js
@@ -31,3 +31,21 @@ export const getCohortUsers = ({ cohort, ...rest }) => laboratoriaAPIAction({
   expiration: 1000 * 60 * 5,
   ...rest,
 });
+
+export const getCohortProjects = ({ cohort, ...rest }) => laboratoriaAPIAction({
+  type: 'COHORT_PROJECTS',
+  url: `/cohorts/${cohort}/projects`,
+  method: 'GET',
+  key: `cohorts/${cohort}/projects`,
+  expiration: 1000 * 60 * 5,
+  ...rest,
+});
+
+export const addCohortProject = ({ cohort, project, ...rest }) => laboratoriaAPIAction({
+  type: 'COHORT_PROJECT_ADD',
+  url: `/cohorts/${cohort}/projects`,
+  method: 'POST',
+  data: project,
+  key: 'cohort-project-add',
+  ...rest,
+});

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -2,6 +2,7 @@ export * from './campuses';
 export * from './cohorts';
 export * from './feedback';
 export * from './profile';
+export * from './projects';
 export * from './reviewer-survey';
 export * from './search';
 export * from './users';

--- a/lib/actions/projects/index.js
+++ b/lib/actions/projects/index.js
@@ -1,0 +1,12 @@
+import { laboratoriaAPIAction } from '../helpers';
+
+export const getProjects = ({
+  ...rest
+} = {}) => laboratoriaAPIAction({
+  type: 'PROJECTS',
+  url: '/projects',
+  method: 'GET',
+  key: 'projects',
+  expiration: 1000 * 60 * 60,
+  ...rest,
+});

--- a/test/actions/__snapshots__/campuses.spec.js.snap
+++ b/test/actions/__snapshots__/campuses.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getCohorts should create an appropriate action 1`] = `
+exports[`getCampuses should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,

--- a/test/actions/__snapshots__/cohorts.spec.js.snap
+++ b/test/actions/__snapshots__/cohorts.spec.js.snap
@@ -1,6 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getCohortUsers should create an appropriate action 1`] = `
+exports[`addCohortProject should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "cohort-project-add",
+    "namespace": "default",
+    "suffix": "COHORT_PROJECT_ADD",
+  },
+  "payload": Object {
+    "data": Object {
+      "id": "projectId",
+    },
+    "headers": undefined,
+    "method": "POST",
+    "params": undefined,
+    "url": "/cohorts/someone/projects",
+  },
+  "type": "@@api-client/API_REQUEST/COHORT_PROJECT_ADD",
+}
+`;
+
+exports[`getCohortProjects should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 300000,
+    "key": "cohorts/someone/projects",
+    "namespace": "default",
+    "suffix": "COHORT_PROJECTS",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/cohorts/someone/projects",
+  },
+  "type": "@@api-client/API_REQUEST/COHORT_PROJECTS",
+}
+`;
+
+exports[`getCohortUsers should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,
@@ -20,7 +62,7 @@ Object {
 }
 `;
 
-exports[`getCohorts should create an appropriate action 1`] = `
+exports[`getCohorts should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addComment should create an appropiate action 1`] = `
+exports[`addComment should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,
@@ -24,7 +24,7 @@ Object {
 }
 `;
 
-exports[`deleteComment should create an appropiate action 1`] = `
+exports[`deleteComment should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,
@@ -44,7 +44,7 @@ Object {
 }
 `;
 
-exports[`getComments should create an appropiate action 1`] = `
+exports[`getComments should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,
@@ -64,7 +64,7 @@ Object {
 }
 `;
 
-exports[`updateComment should create an appropiate action 1`] = `
+exports[`updateComment should create an action 1`] = `
 Object {
   "meta": Object {
     "anonymous": undefined,

--- a/test/actions/__snapshots__/projects.spec.js.snap
+++ b/test/actions/__snapshots__/projects.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getProjects should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 3600000,
+    "key": "projects",
+    "namespace": "default",
+    "suffix": "PROJECTS",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/projects",
+  },
+  "type": "@@api-client/API_REQUEST/PROJECTS",
+}
+`;

--- a/test/actions/campuses.spec.js
+++ b/test/actions/campuses.spec.js
@@ -1,11 +1,11 @@
 import { getCampuses } from '../../lib/actions/campuses';
 
-describe('getCohorts', () => {
+describe('getCampuses', () => {
   it('should be a function', () => {
     expect(typeof getCampuses).toBe('function');
   });
 
-  it('should create an appropriate action', () => {
+  it('should create an action', () => {
     expect(getCampuses()).toMatchSnapshot();
   });
 });

--- a/test/actions/cohorts.spec.js
+++ b/test/actions/cohorts.spec.js
@@ -1,11 +1,16 @@
-import { getCohorts, getCohortUsers } from '../../lib/actions/cohorts';
+import {
+  getCohorts,
+  getCohortUsers,
+  getCohortProjects,
+  addCohortProject,
+} from '../../lib/actions/cohorts';
 
 describe('getCohorts', () => {
   it('should be a function', () => {
     expect(typeof getCohorts).toBe('function');
   });
 
-  it('should create an appropriate action', () => {
+  it('should create an action', () => {
     expect(getCohorts()).toMatchSnapshot();
   });
 });
@@ -15,7 +20,32 @@ describe('getCohortUsers', () => {
     expect(typeof getCohortUsers).toBe('function');
   });
 
-  it('should create an appropriate action', () => {
+  it('should create an action', () => {
     expect(getCohortUsers({ cohort: 'something' })).toMatchSnapshot();
+  });
+});
+
+describe('getCohortProjects', () => {
+  it('should be a function', () => {
+    expect(typeof getCohortProjects).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(getCohortProjects({ cohort: 'someone' })).toMatchSnapshot();
+  });
+});
+
+describe('addCohortProject', () => {
+  it('should be a function', () => {
+    expect(typeof addCohortProject).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(addCohortProject({
+      cohort: 'someone',
+      project: {
+        id: 'projectId',
+      },
+    })).toMatchSnapshot();
   });
 });

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -10,7 +10,7 @@ describe('getComments', () => {
     expect(typeof getComments).toBe('function');
   });
 
-  it('should create an appropiate action', () => {
+  it('should create an action', () => {
     expect(getComments({ user: 'someone' })).toMatchSnapshot();
   });
 });
@@ -20,7 +20,7 @@ describe('addComment', () => {
     expect(typeof addComment).toBe('function');
   });
 
-  it('should create an appropiate action', () => {
+  it('should create an action', () => {
     expect(addComment({
       user: 'someone',
       comment: {
@@ -37,7 +37,7 @@ describe('updateComment', () => {
     expect(typeof updateComment).toBe('function');
   });
 
-  it('should create an appropiate action', () => {
+  it('should create an action', () => {
     expect(updateComment({
       user: 'someone',
       comment: {
@@ -53,7 +53,7 @@ describe('deleteComment', () => {
     expect(typeof deleteComment).toBe('function');
   });
 
-  it('should create an appropiate action', () => {
+  it('should create an action', () => {
     expect(deleteComment({
       user: 'someone',
       commentId: 'commentId',

--- a/test/actions/projects.spec.js
+++ b/test/actions/projects.spec.js
@@ -1,0 +1,11 @@
+import { getProjects } from '../../lib/actions/projects';
+
+describe('getProjects', () => {
+  it('should be a function', () => {
+    expect(typeof getProjects).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(getProjects()).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This adds  actions to use cohort projects GET endpoint, including:

- getProjects, getCohortProjects and addCohortProject actions
- Tests of getProjects, getCohortProjects and addCohortProject actions
- Snapshot for getProjects, getCohortProjects and addCohortProject  actions
- Documentation for getProjects, getCohortProjects and addCohortProject  actions

And corrections in terms of spelling and rename of function