### PR TITLE
feat(profile): Add actions for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,12 +269,45 @@ Update a user's profile comment.
 - `comment`: Object representing the comment to update. Must contain an `id` property.
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
 
+#### `addProfileTag({ user, tag, ...rest })`
+Add a tag to a user's academic profile.
+
+##### Params
+- `user`: User ID or email whose profile the tag will be added to.
+- `data`: AcademicProfileTag content.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+#### `deleteProfileTag({ user, tagId, ...rest })`
+Delete a user's profile tag.
+
+##### Params
+- `user`: User ID or email whose profile the tag will be deleted from.
+- `tagId`: AcademicProfileTag ID.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+#### `getProfileTags({ user, ...rest })`
+Get a user's profile tags.
+
+##### Params
+- `user`: User ID or email whose profile the tag will be retrieved from.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
+#### `updateProfileTag({ user, tag: { id, ...data }, ...rest })`
+Update a user's profile tag.
+
+##### Params
+- `user`: User ID or email whose profile the tag will be updated from.
+- `tagId`: AcademicProfileTag ID.
+- `data`: AcademicProfileTag content.
+- `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
 ### Campuses
 #### `getCampuses({ ...rest })`
 Get projects list.
 
 ##### Params
 - `rest`: Other parameters to be passed to `laboratoriaAPIAction`.
+
 
 ### Reviewer Survey
 #### `getLastestVersion()`

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -56,3 +56,17 @@ export const addProfileTag = ({ user, data, ...rest }) => laboratoriaAPIAction({
   key: 'profile-tag-add',
   ...rest,
 });
+
+export const updateProfileTag = ({
+  user,
+  tagId,
+  data,
+  ...rest
+}) => laboratoriaAPIAction({
+  type: 'PROFILE_TAG_UPDATE',
+  url: `/users/${user}/profile/tags/${tagId}`,
+  method: 'PUT',
+  data,
+  key: 'profile-tag-update',
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -47,3 +47,12 @@ export const getProfileTags = ({ user, ...rest }) => laboratoriaAPIAction({
   expiration: 1000 * 60 * 5,
   ...rest,
 });
+
+export const addProfileTag = ({ user, data, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_TAG_ADD',
+  url: `/users/${user}/profile/tags`,
+  method: 'POST',
+  data,
+  key: 'profile-tag-add',
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -70,3 +70,11 @@ export const updateProfileTag = ({
   key: 'profile-tag-update',
   ...rest,
 });
+
+export const deleteProfileTag = ({ user, tagId, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_TAG_DELETE',
+  url: `/users/${user}/profile/tags/${tagId}`,
+  method: 'DELETE',
+  key: 'profile-tag-delete',
+  ...rest,
+});

--- a/lib/actions/profile/index.js
+++ b/lib/actions/profile/index.js
@@ -38,3 +38,12 @@ export const deleteComment = ({ user, commentId, ...rest }) => laboratoriaAPIAct
   key: 'profile-comment-delete',
   ...rest,
 });
+
+export const getProfileTags = ({ user, ...rest }) => laboratoriaAPIAction({
+  type: 'PROFILE_TAGS',
+  url: `/users/${user}/profile/tags`,
+  method: 'GET',
+  key: `user/${user}/profile/tags`,
+  expiration: 1000 * 60 * 5,
+  ...rest,
+});

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -24,6 +24,29 @@ Object {
 }
 `;
 
+exports[`addProfileTag should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-tag-add",
+    "namespace": "default",
+    "suffix": "PROFILE_TAG_ADD",
+  },
+  "payload": Object {
+    "data": Object {
+      "assignmentReason": "a comment",
+      "tag": "tagId",
+    },
+    "headers": undefined,
+    "method": "POST",
+    "params": undefined,
+    "url": "/users/someone/profile/tags",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_TAG_ADD",
+}
+`;
+
 exports[`deleteComment should create an action 1`] = `
 Object {
   "meta": Object {

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -128,3 +128,25 @@ Object {
   "type": "@@api-client/API_REQUEST/PROFILE_COMMENT_UPDATE",
 }
 `;
+
+exports[`updateProfileTag should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-tag-update",
+    "namespace": "default",
+    "suffix": "PROFILE_TAG_UPDATE",
+  },
+  "payload": Object {
+    "data": Object {
+      "removalReasson": "a comment",
+    },
+    "headers": undefined,
+    "method": "PUT",
+    "params": undefined,
+    "url": "/users/someone/profile/tags/tagId",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_TAG_UPDATE",
+}
+`;

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -64,6 +64,26 @@ Object {
 }
 `;
 
+exports[`getProfileTags should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": 300000,
+    "key": "user/someone/profile/tags",
+    "namespace": "default",
+    "suffix": "PROFILE_TAGS",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "GET",
+    "params": undefined,
+    "url": "/users/someone/profile/tags",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_TAGS",
+}
+`;
+
 exports[`updateComment should create an action 1`] = `
 Object {
   "meta": Object {

--- a/test/actions/__snapshots__/profile.spec.js.snap
+++ b/test/actions/__snapshots__/profile.spec.js.snap
@@ -67,6 +67,26 @@ Object {
 }
 `;
 
+exports[`deleteProfileTag should create an action 1`] = `
+Object {
+  "meta": Object {
+    "anonymous": undefined,
+    "expiration": undefined,
+    "key": "profile-tag-delete",
+    "namespace": "default",
+    "suffix": "PROFILE_TAG_DELETE",
+  },
+  "payload": Object {
+    "data": undefined,
+    "headers": undefined,
+    "method": "DELETE",
+    "params": undefined,
+    "url": "/users/someone/profile/tags/tagId",
+  },
+  "type": "@@api-client/API_REQUEST/PROFILE_TAG_DELETE",
+}
+`;
+
 exports[`getComments should create an action 1`] = `
 Object {
   "meta": Object {

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -6,6 +6,7 @@ import {
   getProfileTags,
   addProfileTag,
   updateProfileTag,
+  deleteProfileTag,
 } from '../../lib/actions/profile';
 
 describe('getComments', () => {
@@ -102,6 +103,19 @@ describe('updateProfileTag', () => {
       data: {
         removalReasson: 'a comment',
       },
+    })).toMatchSnapshot();
+  });
+});
+
+describe('deleteProfileTag', () => {
+  it('should be a function', () => {
+    expect(typeof deleteProfileTag).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(deleteProfileTag({
+      user: 'someone',
+      tagId: 'tagId',
     })).toMatchSnapshot();
   });
 });

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -5,6 +5,7 @@ import {
   deleteComment,
   getProfileTags,
   addProfileTag,
+  updateProfileTag,
 } from '../../lib/actions/profile';
 
 describe('getComments', () => {
@@ -84,6 +85,22 @@ describe('addProfileTag', () => {
       data: {
         assignmentReason: 'a comment',
         tag: 'tagId',
+      },
+    })).toMatchSnapshot();
+  });
+});
+
+describe('updateProfileTag', () => {
+  it('should be a function', () => {
+    expect(typeof updateProfileTag).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(updateProfileTag({
+      user: 'someone',
+      tagId: 'tagId',
+      data: {
+        removalReasson: 'a comment',
       },
     })).toMatchSnapshot();
   });

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -4,6 +4,7 @@ import {
   updateComment,
   deleteComment,
   getProfileTags,
+  addProfileTag,
 } from '../../lib/actions/profile';
 
 describe('getComments', () => {
@@ -69,5 +70,21 @@ describe('getProfileTags', () => {
 
   it('should create an action', () => {
     expect(getProfileTags({ user: 'someone' })).toMatchSnapshot();
+  });
+});
+
+describe('addProfileTag', () => {
+  it('should be a function', () => {
+    expect(typeof addProfileTag).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(addProfileTag({
+      user: 'someone',
+      data: {
+        assignmentReason: 'a comment',
+        tag: 'tagId',
+      },
+    })).toMatchSnapshot();
   });
 });

--- a/test/actions/profile.spec.js
+++ b/test/actions/profile.spec.js
@@ -3,6 +3,7 @@ import {
   addComment,
   updateComment,
   deleteComment,
+  getProfileTags,
 } from '../../lib/actions/profile';
 
 describe('getComments', () => {
@@ -58,5 +59,15 @@ describe('deleteComment', () => {
       user: 'someone',
       commentId: 'commentId',
     })).toMatchSnapshot();
+  });
+});
+
+describe('getProfileTags', () => {
+  it('should be a function', () => {
+    expect(typeof getProfileTags).toBe('function');
+  });
+
+  it('should create an action', () => {
+    expect(getProfileTags({ user: 'someone' })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This pull request implements the necessary _actions_ to consume the endpoints of the **academic profile tags**, as well as the corresponding tests and documentation.